### PR TITLE
Remove deprecated rdoc spec statement

### DIFF
--- a/resque-loner.gemspec
+++ b/resque-loner.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.email = ['jannis@moviepilot.com']
   s.homepage = 'http://github.com/jayniz/resque-loner'
   s.summary = 'Adds unique jobs to resque'
-  s.has_rdoc = false
   s.license = 'MIT'
 
   s.rubyforge_project = 'resque-loner'


### PR DESCRIPTION
This has been deprecated since 2018 and started breaking things with the amazon linux v2 upgrade